### PR TITLE
list graph.nodes for py3 compatibility

### DIFF
--- a/simuling/simulation.py
+++ b/simuling/simulation.py
@@ -27,7 +27,7 @@ class LanguageForwardSimulation (object):
         self.logfile = logfile
 
     def random_speaker(self):
-        return self.random.choice(self.population_graph.nodes())
+        return self.random.choice(list(self.population_graph.nodes()))
 
     def random_speaker_among(self, neighbours):
         return self.population_graph.node[


### PR DESCRIPTION
as I'm using py3, and networkx now has generators, graph.nodes() should be list(graph.nodes()). With this patch, the simulation runs fine for me.