### PR TITLE
Make word list collection more flexible

### DIFF
--- a/phylo/cli.py
+++ b/phylo/cli.py
@@ -25,14 +25,17 @@ def run(times=100, signs=1000, fields=50,
     for i in range(times):
         phy = Phylogeny(
             related_concepts,
+            basic=basic_list,
             tree=lingpy.basic.tree.Tree(
                 lingpy.basic.tree.random_tree(
                     taxa, branch_lengths=False)),
             change_range=(change_min, change_range))
 
+        phy.simulate()
+
         # "basic" is the number of words we afterwards use to to infer
         # phylogeny with neighbor-joining
-        dataframe, columns = phy.collect_word_list(basic=basic_list)
+        dataframe, columns = phy.collect_word_list()
         D = {index+1: list(row) for index, row in enumerate(dataframe)}
         D[0] = columns
 

--- a/phylo/language.py
+++ b/phylo/language.py
@@ -199,7 +199,7 @@ class Language(object):
         For each cognate class (i.e. each word) that has any meaning
         with activation above `threshold`, give it and its most
         salient meaning.
-        
+
         Language.all_reflexes is one possible value for the `method`
         argument of `Phylogeny.collect_wordlist`.
 

--- a/phylo/language.py
+++ b/phylo/language.py
@@ -193,6 +193,25 @@ class Language(object):
                 yield concept, word
                 weightsum += weight
 
+    def all_reflexes(self, threshold=0):
+        """Sequence of all reflexes in the language
+
+        For each cognate class (i.e. each word) that has any meaning
+        with activation above `threshold`, give it and its most
+        salient meaning.
+        
+        Language.all_reflexes is one possible value for the `method`
+        argument of `Phylogeny.collect_wordlist`.
+
+        """
+        words = {}
+        for (word, meaning), weight in self.flat_frequencies().items():
+            old_meaning, old_weight = words.get(word, (None, threshold))
+            if weight > old_weight:
+                words[word] = (meaning, weight)
+        for word, (meaning, weight) in words.items():
+            yield (meaning, word)
+
     def change(self,
                p_lose=0.5,
                p_gain=0.4,

--- a/phylo/phylo.py
+++ b/phylo/phylo.py
@@ -47,13 +47,13 @@ class Phylogeny(object):
                 self.tracer[node.Name] = {
                         'language': new_language,
                         'distance': distance}
-        
+
     def collect_word_list(
             self,
             method=None,
             collect_tips_only=True):
         """Collect word lists from all (tip) languages in the tree.
-        
+
         Create a CLDF-/lingpy-like list of (language_id, feature_id,
         value, cognate_class) tuples by sampling each language
         according to method.
@@ -71,7 +71,7 @@ class Phylogeny(object):
         if method is None:
             def method(language):
                 return Language.basic_vocabulary(language, self.basic)
-            
+
         columns = ('doculect', 'concept', 'ipa', 'cogid')
         word_list = []
         concept_cogid_pairs = {}


### PR DESCRIPTION
Split the simulation from the word list collection.
Then, make the word list collection take an argument for a collection
method, and implement another (`all_reflexes`) such method, as suggested
by Mattis.

Also fix where arguments are passed to what in the process.

 - [ ] Allow the CLI to user other collection methods
 - [ ] Allow the CLI to sample and compare *multiple* collection methods from the same tree.